### PR TITLE
fix: prevent crash when navbar is null/undefined in SSR error path

### DIFF
--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -107,7 +107,7 @@ const Nav = ({ navbar }: any) => {
               open ? "top-20" : "top-[-490px]"
             }`}
           >
-            {navbar.map((link: any) => (
+            {(navbar ?? []).map((link: any) => (
               <li key={link.name} className="md:ml-8 text-xl md:my-0 my-7">
                 <Link
                   href={link.link}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -145,7 +145,7 @@ export async function getServerSideProps() {
     }
   } catch (error) {
     console.error("Error fetching data:", error)
-    return { props: { error: "Failed to fetch data" } }
+    return { props: { error: "Failed to fetch data", navbar: [] } }
   }
 }
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -143,7 +143,7 @@ export async function getServerSideProps(context: any) {
     }
   } catch (error) {
     console.error("Error fetching data:", error)
-    return { props: { error: "Failed to fetch data" } }
+    return { props: { error: "Failed to fetch data", navbar: [] } }
   }
 }
 

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -223,6 +223,6 @@ export async function getServerSideProps() {
     return { props: { social: rsocials, contato, posts, navbar: dlink } }
   } catch (error) {
     console.error("Error fetching data:", error)
-    return { props: { error: "Failed to fetch data" } }
+    return { props: { error: "Failed to fetch data", navbar: [] } }
   }
 }


### PR DESCRIPTION
Nav: guard navbar.map with (navbar ?? []) so undefined never crashes SSR. index, posts/[slug], posts/index: include navbar:[] in catch fallback props so Layout always receives a safe value even when the API is unreachable.