### PR TITLE
fix: switch to Promise.allSettled and guard Footer against null contato

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -30,7 +30,8 @@ interface FooterProps {
   }
 }
 
-const Footer: React.FC<FooterProps> = ({ rsocial, contato }) => {
+const Footer: React.FC<FooterProps> = ({ rsocial, contato = null }) => {
+  const contact = contato?.data?.attributes
   const {
     register,
     handleSubmit,
@@ -96,11 +97,11 @@ const Footer: React.FC<FooterProps> = ({ rsocial, contato }) => {
                 <Image src={logo} alt="logo" />
               </h4>
               <p className="text-gray-300">
-                {contato.data.attributes.Local}
+                {contact?.Local}
                 <br />
-                {contato.data.attributes.phone}
+                {contact?.phone}
                 <br />
-                {contato.data.attributes.email}
+                {contact?.email}
               </p>
             </div>
 
@@ -142,7 +143,7 @@ const Footer: React.FC<FooterProps> = ({ rsocial, contato }) => {
                 Subscreva A Nossa NewsLetter
               </h4>
               <p className="text-gray-300 pb-2">
-                {contato.data.attributes.newsletterTitle}
+                {contact?.newsletterTitle}
               </p>
               <form
                 onSubmit={handleSubmit(onSubmit)}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -117,7 +117,7 @@ export async function getServerSideProps() {
   )
 
   try {
-    const [rsocials, contato, banners, edicao, navbar] = await Promise.all([
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(
@@ -127,20 +127,24 @@ export async function getServerSideProps() {
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
 
-    const dlink = parseNavbar(navbar)
+    const [rsocials, contato, banners, edicao, navbar] = results.map((r) => {
+      if (r.status === "fulfilled") return r.value
+      console.error("Endpoint failed:", (r as PromiseRejectedResult).reason)
+      return null
+    })
 
     return {
       props: {
-        social: rsocials,
-        contato,
-        banners,
-        edicao: edicao?.data?.[0],
-        navbar: dlink,
+        social: rsocials ?? null,
+        contato: contato ?? null,
+        banners: banners ?? null,
+        edicao: edicao?.data?.[0] ?? null,
+        navbar: parseNavbar(navbar),
       },
     }
   } catch (error) {
     console.error("Error fetching data:", error)
-    return { props: { error: "Failed to fetch data", navbar: [] } }
+    return { props: { error: "Failed to fetch data", social: null, contato: null, navbar: [] } }
   }
 }
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -106,7 +106,7 @@ const PostDetail = ({
 export async function getServerSideProps(context: any) {
   try {
     const { slug } = context.params
-    const [rsocials, contato, post, navbar] = await Promise.all([
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(
@@ -114,6 +114,12 @@ export async function getServerSideProps(context: any) {
       ),
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
+
+    const [rsocials, contato, post, navbar] = results.map((r) => {
+      if (r.status === "fulfilled") return r.value
+      console.error("Endpoint failed:", (r as PromiseRejectedResult).reason)
+      return null
+    })
 
     const dlink = parseNavbar(navbar)
 
@@ -127,8 +133,8 @@ export async function getServerSideProps(context: any) {
 
     return {
       props: {
-        social: rsocials,
-        contato,
+        social: rsocials ?? null,
+        contato: contato ?? null,
         post,
         navbar: dlink,
         previousPost:
@@ -138,7 +144,7 @@ export async function getServerSideProps(context: any) {
     }
   } catch (error) {
     console.error("Error fetching data:", error)
-    return { props: { error: "Failed to fetch data", navbar: [] } }
+    return { props: { error: "Failed to fetch data", social: null, contato: null, navbar: [] } }
   }
 }
 

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -204,7 +204,7 @@ export default PostList
 
 export async function getServerSideProps() {
   try {
-    const [rsocials, contato, posts, navbar] = await Promise.all([
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(
@@ -213,11 +213,15 @@ export async function getServerSideProps() {
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
 
-    const dlink = parseNavbar(navbar)
+    const [rsocials, contato, posts, navbar] = results.map((r) => {
+      if (r.status === "fulfilled") return r.value
+      console.error("Endpoint failed:", (r as PromiseRejectedResult).reason)
+      return null
+    })
 
-    return { props: { social: rsocials, contato, posts, navbar: dlink } }
+    return { props: { social: rsocials ?? null, contato: contato ?? null, posts, navbar: parseNavbar(navbar) } }
   } catch (error) {
     console.error("Error fetching data:", error)
-    return { props: { error: "Failed to fetch data", navbar: [] } }
+    return { props: { error: "Failed to fetch data", social: null, contato: null, navbar: [] } }
   }
 }


### PR DESCRIPTION
/api/redes-social returns 404 (collection missing in Strapi), causing Promise.all to reject and the catch block to return props without contato/social, which made Footer crash on contato.data.attributes.

- Replace Promise.all with Promise.allSettled in index, posts/index, posts/[slug] so one failing endpoint no longer brings down the page
- Each failed result logs a warning and falls back to null
- Add social:null and contato:null to every catch fallback
- Footer: extract contato?.data?.attributes into a safe local variable so all accesses use optional chaining and never throw