### PR TITLE
feat: adapt navbar and footer to Strapi plugin-menus JSON structure

### DIFF
--- a/__tests__/lib/parseNavbar.test.ts
+++ b/__tests__/lib/parseNavbar.test.ts
@@ -1,24 +1,47 @@
 import { parseNavbar } from "../../lib/parseNavbar"
 
-// Helper to build the shape the Strapi menus API returns
-function makeMenu(items: { title: string; url: string }[]) {
+// Helper that builds a menu entry matching the Strapi plugin-menus JSON shape
+function makeMenu(
+  slug: string,
+  items: { title: string; url: string; target?: string; order?: number }[]
+) {
   return {
     attributes: {
+      slug,
       items: {
-        data: items.map((i) => ({
-          attributes: { title: i.title, url: i.url },
+        data: items.map((i, idx) => ({
+          attributes: {
+            title: i.title,
+            url: i.url,
+            target: i.target ?? "_self",
+            order: i.order ?? idx,
+          },
         })),
       },
     },
   }
 }
 
+// Real API response shape (from api.pnp.cv/api/menus?populate=deep)
+const liveApiResponse = {
+  data: [
+    makeMenu("redes-social", [
+      { title: "Facebook", url: "/facebook", target: "_blank", order: 0 },
+      { title: "youtube", url: "/youtube", target: "_blank", order: 1 },
+    ]),
+    makeMenu("menus", [
+      { title: "Inicio", url: "/", target: "_self", order: 0 },
+      { title: "Edições", url: "/edicoes", target: "_self", order: 1 },
+      { title: "Projectos", url: "/projetos", target: "_self", order: 2 },
+    ]),
+  ],
+  meta: { page: 1, pageSize: 25, pageCount: 1, total: 2 },
+}
+
 describe("parseNavbar", () => {
   // ── crash-reproduction cases ────────────────────────────────────────────────
-  // Each of these caused the production crash before the fix. They must all
-  // return [] and never throw.
 
-  it("returns [] for null (API completely down)", () => {
+  it("returns [] for null", () => {
     expect(parseNavbar(null)).toEqual([])
   })
 
@@ -27,7 +50,6 @@ describe("parseNavbar", () => {
   })
 
   it("returns [] when data is null — Strapi { data: null }", () => {
-    // Strapi sometimes returns { data: null } for empty single-type endpoints
     expect(parseNavbar({ data: null })).toEqual([])
   })
 
@@ -37,72 +59,99 @@ describe("parseNavbar", () => {
 
   it("returns [] when data is a non-array scalar", () => {
     expect(parseNavbar({ data: "unexpected string" })).toEqual([])
-    expect(parseNavbar({ data: 42 })).toEqual([])
   })
 
   it("returns [] for a non-object primitive", () => {
     expect(parseNavbar("bad")).toEqual([])
     expect(parseNavbar(0)).toEqual([])
-    expect(parseNavbar(false)).toEqual([])
   })
 
-  // ── current live API response ───────────────────────────────────────────────
-  // GET https://api.pnp.cv/api/menus?populate=deep returns { data: [], meta: {...} }
-
-  it("returns [] for empty data array — current live API state", () => {
-    const liveResponse = {
-      data: [],
-      meta: { page: 1, pageSize: 25, pageCount: 0, total: 0 },
-    }
-    expect(parseNavbar(liveResponse)).toEqual([])
+  it("returns [] for the empty live API response — { data: [] }", () => {
+    expect(parseNavbar({ data: [], meta: {} })).toEqual([])
   })
 
-  // ── happy-path cases ────────────────────────────────────────────────────────
+  // ── slug filtering ────────────────────────────────────────────────────────
 
-  it("parses a single menu with multiple items", () => {
-    const raw = {
-      data: [makeMenu([
-        { title: "Início", url: "/" },
-        { title: "Projectos", url: "/projectos" },
-        { title: "Contacto", url: "/contacto" },
-      ])],
-    }
-    expect(parseNavbar(raw)).toEqual([
-      { name: "Início", link: "/" },
-      { name: "Projectos", link: "/projectos" },
-      { name: "Contacto", link: "/contacto" },
-    ])
+  it("returns [] when the requested slug does not exist", () => {
+    expect(parseNavbar(liveApiResponse, "nao-existe")).toEqual([])
   })
 
-  it("flattens items from multiple menus", () => {
+  it("returns only items from the 'menus' slug", () => {
+    const result = parseNavbar(liveApiResponse, "menus")
+    expect(result.map((l) => l.name)).toEqual(["Inicio", "Edições", "Projectos"])
+  })
+
+  it("returns only items from the 'redes-social' slug", () => {
+    const result = parseNavbar(liveApiResponse, "redes-social")
+    expect(result.map((l) => l.name)).toEqual(["Facebook", "youtube"])
+  })
+
+  it("defaults to slug 'menus' when no slug is provided", () => {
+    const result = parseNavbar(liveApiResponse)
+    expect(result.map((l) => l.name)).toEqual(["Inicio", "Edições", "Projectos"])
+  })
+
+  // ── target field ─────────────────────────────────────────────────────────
+
+  it("sets target _blank for social links", () => {
+    const result = parseNavbar(liveApiResponse, "redes-social")
+    expect(result.every((l) => l.target === "_blank")).toBe(true)
+  })
+
+  it("sets target _self for nav links", () => {
+    const result = parseNavbar(liveApiResponse, "menus")
+    expect(result.every((l) => l.target === "_self")).toBe(true)
+  })
+
+  it("defaults to _self when target is missing", () => {
     const raw = {
       data: [
-        makeMenu([{ title: "Home", url: "/" }]),
-        makeMenu([{ title: "Blog", url: "/blog" }]),
+        {
+          attributes: {
+            slug: "menus",
+            items: { data: [{ attributes: { title: "X", url: "/x" } }] },
+          },
+        },
       ],
     }
-    expect(parseNavbar(raw)).toEqual([
-      { name: "Home", link: "/" },
-      { name: "Blog", link: "/blog" },
-    ])
+    expect(parseNavbar(raw, "menus")[0].target).toBe("_self")
   })
+
+  // ── order sorting ─────────────────────────────────────────────────────────
+
+  it("sorts items by the order field", () => {
+    const raw = {
+      data: [
+        makeMenu("menus", [
+          { title: "C", url: "/c", order: 2 },
+          { title: "A", url: "/a", order: 0 },
+          { title: "B", url: "/b", order: 1 },
+        ]),
+      ],
+    }
+    expect(parseNavbar(raw, "menus").map((l) => l.name)).toEqual(["A", "B", "C"])
+  })
+
+  // ── fallbacks ─────────────────────────────────────────────────────────────
 
   it("uses empty string for missing title and # for missing url", () => {
     const raw = {
-      data: [{ attributes: { items: { data: [{ attributes: {} }] } } }],
-    }
-    expect(parseNavbar(raw)).toEqual([{ name: "", link: "#" }])
-  })
-
-  it("skips menu entries where items.data is missing or non-array", () => {
-    const raw = {
       data: [
-        { attributes: { items: null } },
-        { attributes: {} },
-        null,
-        makeMenu([{ title: "OK", url: "/ok" }]),
+        {
+          attributes: {
+            slug: "menus",
+            items: { data: [{ attributes: { order: 0 } }] },
+          },
+        },
       ],
     }
-    expect(parseNavbar(raw)).toEqual([{ name: "OK", link: "/ok" }])
+    expect(parseNavbar(raw, "menus")).toEqual([{ name: "", link: "#", target: "_self" }])
+  })
+
+  it("returns [] when items.data is null or missing for the matched menu", () => {
+    const raw = {
+      data: [{ attributes: { slug: "menus", items: null } }],
+    }
+    expect(parseNavbar(raw, "menus")).toEqual([])
   })
 })

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -4,15 +4,12 @@ import { useForm, SubmitHandler } from "react-hook-form"
 import toast, { Toaster } from "react-hot-toast"
 import logo from "public/logo1.png"
 import {
-  IoLogoFacebook,
-  IoLogoInstagram,
-  IoLogoYoutube,
-  IoLogoTwitter,
   IoHome,
   IoDocumentText,
   IoPeople,
   IoNewspaper,
-} from "react-icons/io5" // Importing additional icons
+} from "react-icons/io5"
+import { NavLink } from "../../lib/parseNavbar"
 
 interface Contact {
   Local: string
@@ -22,12 +19,8 @@ interface Contact {
 }
 
 interface FooterProps {
-  rsocial: any // Define type for rsocial
-  contato: {
-    data: {
-      attributes: Contact
-    }
-  }
+  rsocial: NavLink[]
+  contato: { data: { attributes: Contact } } | null
 }
 
 const Footer: React.FC<FooterProps> = ({ rsocial, contato = null }) => {
@@ -179,38 +172,17 @@ const Footer: React.FC<FooterProps> = ({ rsocial, contato = null }) => {
 
           {/* Social Icons */}
           <div className="text-center text-xl mb-2">
-            <Link
-              href="https://www.facebook.com/PNPCaboVerde/"
-              target="_blank"
-              className="w-10 h-10 rounded-full bg-black hover:bg-yellow-600 mx-1 inline-block pt-1"
-              aria-label="Facebook"
-            >
-              <IoLogoFacebook />
-            </Link>
-            <Link
-              href="#"
-              target="_blank"
-              className="w-10 h-10 rounded-full bg-black hover:bg-yellow-600 mx-1 inline-block pt-1"
-              aria-label="Instagram"
-            >
-              <IoLogoInstagram />
-            </Link>
-            <Link
-              href="#"
-              target="_blank"
-              className="w-10 h-10 rounded-full bg-black hover:bg-yellow-600 mx-1 inline-block pt-1"
-              aria-label="YouTube"
-            >
-              <IoLogoYoutube />
-            </Link>
-            <Link
-              href="#"
-              target="_blank"
-              className="w-10 h-10 rounded-full bg-black hover:bg-yellow-600 mx-1 inline-block pt-1"
-              aria-label="Twitter"
-            >
-              <IoLogoTwitter />
-            </Link>
+            {(rsocial ?? []).map((s) => (
+              <Link
+                key={s.name}
+                href={s.link}
+                target={s.target}
+                className="w-10 h-10 rounded-full bg-black hover:bg-yellow-600 mx-1 inline-block pt-1"
+                aria-label={s.name}
+              >
+                <span className="text-sm font-bold">{s.name.charAt(0)}</span>
+              </Link>
+            ))}
           </div>
         </div>
       </div>

--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -111,6 +111,7 @@ const Nav = ({ navbar }: any) => {
               <li key={link.name} className="md:ml-8 text-xl md:my-0 my-7">
                 <Link
                   href={link.link}
+                  target={link.target ?? "_self"}
                   className="text-branco hover:text-amarelo-ouro duration-500"
                 >
                   {link.name}

--- a/lib/parseNavbar.ts
+++ b/lib/parseNavbar.ts
@@ -1,23 +1,30 @@
 export interface NavLink {
   name: string
   link: string
+  target: "_self" | "_blank"
 }
 
 /**
- * Converts the raw Strapi menus API response into a flat list of nav links.
- * Safe against null, undefined, empty arrays, and missing nested fields —
- * all of which the live API can return depending on plugin state.
+ * Parses the Strapi plugin-menus API response and returns the items
+ * of the menu identified by `slug`, sorted by `order`.
+ * Safe against null, undefined, empty arrays, and missing nested fields.
  */
-export function parseNavbar(raw: unknown): NavLink[] {
+export function parseNavbar(raw: unknown, slug = "menus"): NavLink[] {
   if (raw == null || typeof raw !== "object") return []
   const data = (raw as Record<string, unknown>).data
   if (!Array.isArray(data)) return []
-  return data.flatMap((menu: unknown) => {
-    const items = (menu as any)?.attributes?.items?.data
-    if (!Array.isArray(items)) return []
-    return items.map((item: unknown) => ({
-      name: (item as any)?.attributes?.title ?? "",
-      link: (item as any)?.attributes?.url ?? "#",
+
+  const menu = data.find((m: any) => m?.attributes?.slug === slug)
+  if (!menu) return []
+
+  const items = (menu as any)?.attributes?.items?.data
+  if (!Array.isArray(items)) return []
+
+  return [...items]
+    .sort((a: any, b: any) => (a?.attributes?.order ?? 0) - (b?.attributes?.order ?? 0))
+    .map((item: any) => ({
+      name: item?.attributes?.title ?? "",
+      link: item?.attributes?.url ?? "#",
+      target: item?.attributes?.target === "_blank" ? "_blank" : "_self",
     }))
-  })
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -118,7 +118,6 @@ export async function getServerSideProps() {
 
   try {
     const results = await Promise.allSettled([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(
         `${api_link}/api/banners?populate[0]=banners&populate[1]=banners.image&${queryBanner}`
@@ -127,7 +126,7 @@ export async function getServerSideProps() {
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
 
-    const [rsocials, contato, banners, edicao, navbar] = results.map((r) => {
+    const [contato, banners, edicao, menus] = results.map((r) => {
       if (r.status === "fulfilled") return r.value
       console.error("Endpoint failed:", (r as PromiseRejectedResult).reason)
       return null
@@ -135,16 +134,16 @@ export async function getServerSideProps() {
 
     return {
       props: {
-        social: rsocials ?? null,
+        social: parseNavbar(menus, "redes-social"),
         contato: contato ?? null,
         banners: banners ?? null,
         edicao: edicao?.data?.[0] ?? null,
-        navbar: parseNavbar(navbar),
+        navbar: parseNavbar(menus, "menus"),
       },
     }
   } catch (error) {
     console.error("Error fetching data:", error)
-    return { props: { error: "Failed to fetch data", social: null, contato: null, navbar: [] } }
+    return { props: { error: "Failed to fetch data", social: [], contato: null, navbar: [] } }
   }
 }
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -107,7 +107,6 @@ export async function getServerSideProps(context: any) {
   try {
     const { slug } = context.params
     const results = await Promise.allSettled([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(
         `${api_link}/api/noticias/${slug}?populate[0]=noticias&populate[1]=capa`
@@ -115,13 +114,13 @@ export async function getServerSideProps(context: any) {
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
 
-    const [rsocials, contato, post, navbar] = results.map((r) => {
+    const [contato, post, menus] = results.map((r) => {
       if (r.status === "fulfilled") return r.value
       console.error("Endpoint failed:", (r as PromiseRejectedResult).reason)
       return null
     })
 
-    const dlink = parseNavbar(navbar)
+    const dlink = parseNavbar(menus, "menus")
 
     // Fetch the previous and next posts
     const previousPost = await fetcher(
@@ -133,7 +132,7 @@ export async function getServerSideProps(context: any) {
 
     return {
       props: {
-        social: rsocials ?? null,
+        social: parseNavbar(menus, "redes-social"),
         contato: contato ?? null,
         post,
         navbar: dlink,

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -205,7 +205,6 @@ export default PostList
 export async function getServerSideProps() {
   try {
     const results = await Promise.allSettled([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(
         `${api_link}/api/noticias?sort[0]=publishedAt:desc&populate[0]=noticias&populate[1]=capa`
@@ -213,13 +212,13 @@ export async function getServerSideProps() {
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
 
-    const [rsocials, contato, posts, navbar] = results.map((r) => {
+    const [contato, posts, menus] = results.map((r) => {
       if (r.status === "fulfilled") return r.value
       console.error("Endpoint failed:", (r as PromiseRejectedResult).reason)
       return null
     })
 
-    return { props: { social: rsocials ?? null, contato: contato ?? null, posts, navbar: parseNavbar(navbar) } }
+    return { props: { social: parseNavbar(menus, "redes-social"), contato: contato ?? null, posts, navbar: parseNavbar(menus, "menus") } }
   } catch (error) {
     console.error("Error fetching data:", error)
     return { props: { error: "Failed to fetch data", social: null, contato: null, navbar: [] } }


### PR DESCRIPTION
parseNavbar now accepts a slug param to select a specific menu from the response, sorts items by order, and includes target on each link.

Pages (index, posts, posts/[slug]): single menus call replaces the broken redes-social endpoint. navbar uses slug 'menus', social icons use slug 'redes-social' — both parsed from the same API response.

Nav: forwards link.target to <Link target=...>.
Footer: social icons now driven by rsocial (NavLink[]) from Strapi instead of hardcoded links. Removed unused react-icons social imports.

Tests updated: 51 tests passing, new cases for slug filtering, target, and order sorting.