### PR TITLE
fix: complete SSR migration to Promise.allSettled across all pages

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -172,7 +172,7 @@ const Footer: React.FC<FooterProps> = ({ rsocial, contato = null }) => {
 
           {/* Social Icons */}
           <div className="text-center text-xl mb-2">
-            {(rsocial ?? []).map((s) => (
+            {(Array.isArray(rsocial) ? rsocial : []).map((s) => (
               <Link
                 key={s.name}
                 href={s.link}

--- a/pages/contatos.tsx
+++ b/pages/contatos.tsx
@@ -1,5 +1,6 @@
 import Layout from "../components/Layout"
 import { fetcher } from "../lib/api"
+import { parseNavbar } from "../lib/parseNavbar"
 import { useForm, SubmitHandler } from "react-hook-form"
 import Head from "next/head"
 import { useFetchUser } from "../lib/authContext"
@@ -201,27 +202,26 @@ export default CONTATOS
 // Função para buscar dados do servidor
 export async function getServerSideProps() {
   try {
-    const [rsocials, contato, navbar] = await Promise.all([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
+    const [contato, menus] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    const dlink =
-      navbar?.data?.flatMap((value: any) =>
-        value?.attributes?.items?.data?.map((item: any) => ({
-          name: item?.attributes?.title ?? "",
-          link: item?.attributes?.url ?? "#",
-        })) ?? []
-      ) ?? []
 
-    return { props: { social: rsocials, contato, navbar: dlink } }
+    const dlink = parseNavbar(menus, "menus")
+
+    return { props: { social: parseNavbar(menus, "redes-social"), navbar: parseNavbar(menus, "menus") } }
   } catch (error) {
     console.error("Error fetching contatos data:", error)
     return {
       props: {
-        social: { data: null },
-        contato: { data: null },
+        social: [],
+        contato: null,
         navbar: [],
       },
     }

--- a/pages/edicoes/index.tsx
+++ b/pages/edicoes/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import Image from "next/image"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 import Layout from "../../components/Layout"
 import Head from "next/head"
 import HeroSection from "../../components/HeroSection"
@@ -349,29 +350,28 @@ export async function getServerSideProps() {
   const query = new URLSearchParams({ sort: "N_Edicao:desc" })
 
   try {
-    const [rsocials, contato, edicao, navbar] = await Promise.all([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/edicoes?populate=deep&${query.toString()}`),
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
+    const [contato, edicao, menus] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    const dlink =
-      navbar?.data?.flatMap((value: any) =>
-        value?.attributes?.items?.data?.map((item: any) => ({
-          name: item?.attributes?.title ?? "",
-          link: item?.attributes?.url ?? "#",
-        })) ?? []
-      ) ?? []
 
-    return { props: { social: rsocials, contato, edicao, navbar: dlink } }
+    const dlink = parseNavbar(menus, "menus")
+
+    return { props: { social: parseNavbar(menus, "redes-social"), edicao, navbar: parseNavbar(menus, "menus") } }
   } catch (error) {
     console.error("Error fetching edicoes data:", error)
     return {
       props: {
-        social: { data: null },
-        contato: { data: null },
-        edicao: { data: null },
+        social: [],
+        contato: null,
+        edicao: null,
         navbar: [],
       },
     }

--- a/pages/galeria/index.tsx
+++ b/pages/galeria/index.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout";
-import { fetcher } from "../../lib/api";
+import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar";
 const qs = require("qs");
 import Head from "next/head";
 import { useFetchUser } from "../../lib/authContext";
@@ -180,31 +181,30 @@ export async function getServerSideProps({ params, query }: any) {
 	const queries = new URLSearchParams({ sort: "N_Edicao:desc" });
 
 	try {
-		const [rsocials, contato, edicao, navbar] = await Promise.all([
-			fetcher(`${api_link}/api/redes-social?populate=*`),
+    const results = await Promise.allSettled([
 			fetcher(`${api_link}/api/contato`),
 			fetcher(
 				`${api_link}/api/edicoes?populate=deep&${queries.toString()}&filters[N_Edicao][$eq]=${edicao_id}`
 			),
 			fetcher(`${api_link}/api/menus?populate=deep`),
-		]);
+		])
+    const [contato, edicao, menus] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
+;
 
-		const dlink =
-			navbar?.data?.flatMap((value: any) =>
-				value?.attributes?.items?.data?.map((item: any) => ({
-					name: item?.attributes?.title ?? "",
-					link: item?.attributes?.url ?? "#",
-				})) ?? []
-			) ?? [];
+		const dlink = parseNavbar(menus, "menus");
 
-		return { props: { social: rsocials, contato, edicao, navbar: dlink } };
+		return { props: { social: parseNavbar(menus, "redes-social"), edicao, navbar: parseNavbar(menus, "menus") } };
 	} catch (error) {
 		console.error("Error fetching galeria data:", error)
 		return {
 			props: {
-				social: { data: null },
-				contato: { data: null },
-				edicao: { data: null },
+				social: [],
+				contato: null,
+				edicao: null,
 				navbar: [],
 			},
 		}

--- a/pages/inscricao/[id].tsx
+++ b/pages/inscricao/[id].tsx
@@ -1,6 +1,7 @@
 import Head from "next/head"
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 import { useRouter } from "next/router"
 import { Toaster } from "react-hot-toast"
 import { useFetchUser } from "../../lib/authContext"
@@ -143,23 +144,25 @@ export async function getServerSideProps({ query }: { query: Record<string, stri
       return { notFound: true }
     }
 
-    const [rsocials, contato, edicao, navbar] = await Promise.all([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/edicoes?populate=deep&${queri}`),
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
-
-    const navbarLinks =
-      navbar?.data?.flatMap((menu: any) =>
-        menu?.attributes?.items?.data?.map((item: any) => ({
-          name: item?.attributes?.title ?? "",
-          link: item?.attributes?.url ?? "#",
-        })) ?? []
-      ) ?? []
+    const [contato, edicao, menus] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
     return {
-      props: { social: rsocials, contato, edicao, navbar: navbarLinks, inscricao },
+      props: {
+        social: parseNavbar(menus, "redes-social"),
+        contato: contato ?? null,
+        edicao: edicao ?? null,
+        navbar: parseNavbar(menus, "menus"),
+        inscricao,
+      },
     }
   } catch (error) {
     console.error("Erro ao buscar dados:", error)

--- a/pages/inscricao/index.tsx
+++ b/pages/inscricao/index.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 import qs from "qs"
 import Head from "next/head"
 import { useForm, SubmitHandler } from "react-hook-form"
@@ -354,36 +355,34 @@ export async function getServerSideProps() {
   )
 
   try {
-    const [rsocials, contato, edicao, navbar] = await Promise.all([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/edicoes/1?populate=deep&${query}`),
       fetcher(`${api_link}/api/menus?populate=deep`),
     ])
+    const [contato, edicao, menus] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    const dlink =
-      navbar?.data?.flatMap((value: any) =>
-        value?.attributes?.items?.data?.map((item: any) => ({
-          name: item?.attributes?.title ?? "",
-          link: item?.attributes?.url ?? "#",
-        })) ?? []
-      ) ?? []
+
+    const dlink = parseNavbar(menus, "menus")
 
     return {
       props: {
-        social: rsocials,
-        contato,
-        edicao,
-        navbar: dlink,
+        social: parseNavbar(menus, "redes-social"),
+        edicao: edicao ?? null,
+        navbar: parseNavbar(menus, "menus"),
       },
     }
   } catch (error) {
     console.error("Erro ao buscar dados:", error)
     return {
       props: {
-        social: { data: null },
-        contato: { data: null },
-        edicao: { data: null },
+        social: [],
+        contato: null,
+        edicao: null,
         navbar: [],
       },
     }

--- a/pages/juris/[id].tsx
+++ b/pages/juris/[id].tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout";
-import { fetcher } from "../../lib/api";
+import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import showdown from "showdown";
@@ -202,6 +203,6 @@ export async function getServerSideProps({ params, query }: any) {
 
 	// Pass data to the page via props
 	return {
-		props: { social: rsocials, contato, banners, edicao, navbar: dlink },
+		props: { social: contato, banners, edicao, navbar: dlink },
 	};
 }

--- a/pages/parceiros.tsx
+++ b/pages/parceiros.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image"
 import Layout from "../components/Layout"
 import { fetcher } from "../lib/api"
+import { parseNavbar } from "../lib/parseNavbar"
 import Link from "next/link"
 import Head from "next/head"
 import { useFetchUser } from "../lib/authContext"
@@ -170,29 +171,25 @@ export default Parceiros
 // Server-side data fetching
 export async function getServerSideProps() {
   try {
-    const rsocials = await fetcher(`${api_link}/api/redes-social?populate=*`)
-    const contato = await fetcher(`${api_link}/api/contato`)
-    const parceiros = await fetcher(
-      `${api_link}/api/parceiros?populate=deep&sort[0]=id:desc&pagination[pageSize]=1`
-    )
-    const navbar = await fetcher(`${api_link}/api/menus?populate=deep`)
+    const results = await Promise.allSettled([
+      fetcher(`${api_link}/api/contato`),
+      fetcher(`${api_link}/api/parceiros?populate=deep&sort[0]=id:desc&pagination[pageSize]=1`),
+      fetcher(`${api_link}/api/menus?populate=deep`),
+    ])
 
-    // Process navbar links
-    const dlink =
-      navbar?.data?.flatMap((value: any) =>
-        value?.attributes?.items?.data?.map((item: any) => ({
-          name: item?.attributes?.title ?? "",
-          link: item?.attributes?.url ?? "#",
-        })) ?? []
-      ) ?? []
+    const [contato, parceiros, menus] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
     return {
-      props: { social: rsocials, contato, parceiros, navbar: dlink },
+      props: { social: parseNavbar(menus, "redes-social"), contato: contato ?? null, parceiros, navbar: parseNavbar(menus, "menus") },
     }
   } catch (error) {
     console.error("Error fetching data:", error)
     return {
-      props: { social: [], contato: [], parceiros: [], navbar: [] },
+      props: { social: [], contato: null, parceiros: null, navbar: [] },
     }
   }
 }

--- a/pages/perfil/avaliacao.tsx
+++ b/pages/perfil/avaliacao.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 import Link from "next/link"
 import Head from "next/head"
 import { StrapiImage } from "../../components/custom/StrapiImage"
@@ -52,7 +53,7 @@ const Avaliacao = ({
   useEffect(() => {
     if (userId && inscritos.length > 0) {
       const fetchAvaliacoes = async () => {
-        const results = await Promise.all(
+    const results = await Promise.allSettled(
           inscritos.map(async (inscricao: any) => {
             const avaliacao = await getAvaliacaos(inscricao.id, Number(userId))
             return {
@@ -230,42 +231,32 @@ export async function getServerSideProps({ query }: any) {
 
   try {
     // Fetch data concurrently
-    const [edicoes, rsocials, contato, navbar, inscritos] = await Promise.all([
+    const results = await Promise.allSettled([
       fetcher(
         `${api_link}/api/edicoes?populate[categoria][fields]=titulo,id&[populate][inscricoes][fields]=titulo&${queri}`
       ),
-      fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/menus?populate=deep`),
-      fetcher(`${api_link}/api/inscricoes?populate=*`), // Certifique-se de que as inscrições também estão sendo populadas
-      // fetcher(
-      //   `${api_link}/api/avaliacaos?populate[user_id][fields]=id&[populate][inscricoe][fields]=id`
-      // ),
+      fetcher(`${api_link}/api/inscricoes?populate=*`),
     ])
+    const [edicoes, contato, menus, inscritos] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    const totalPages = Math.ceil(edicoes.meta.pagination.total / pageSize)
-    const currentPage = edicoes.meta.pagination.page
-
-    // Navbar parsing
-    const dlink =
-      navbar?.data?.flatMap(
-        (menuItem: any) =>
-          menuItem?.attributes?.items?.data?.map((linkItem: any) => ({
-            name: linkItem?.attributes?.title ?? "Unnamed",
-            link: linkItem?.attributes?.url ?? "#",
-          })) || []
-      ) || []
+    const totalPages = Math.ceil((edicoes?.meta?.pagination?.total ?? 0) / pageSize)
+    const currentPage = edicoes?.meta?.pagination?.page ?? 1
 
     return {
       props: {
-        edicoes: edicoes.data,
-        totalPages, // Add total pages for pagination
-        currentPage, // Add current page
-        social: rsocials,
-        contato,
-        navbar: dlink,
-        inscritos: inscritos.data,
-        // avaliacaos: avaliacaos.data,
+        edicoes: edicoes?.data ?? [],
+        totalPages,
+        currentPage,
+        social: parseNavbar(menus, "redes-social"),
+        contato: contato ?? null,
+        navbar: parseNavbar(menus, "menus"),
+        inscritos: inscritos?.data ?? [],
       },
     }
   } catch (error) {

--- a/pages/perfil/avaliacaoStatus.tsx
+++ b/pages/perfil/avaliacaoStatus.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 // import Link from "next/link"
 import Head from "next/head"
 // import { StrapiImage } from "../../components/custom/StrapiImage"
@@ -248,43 +249,36 @@ export async function getServerSideProps({ query }: any) {
 
   try {
     // Fetch data concurrently
-    const [edicoes, rsocials, contato, navbar, inscritos, avaliacoes] =
-      await Promise.all([
-        fetcher(
-          `${api_link}/api/edicoes?populate[categoria][fields]=titulo,id&[populate][inscricoes][fields]=titulo&${queri}`
-        ),
-        fetcher(`${api_link}/api/redes-social?populate=*`),
-        fetcher(`${api_link}/api/contato`),
-        fetcher(`${api_link}/api/menus?populate=deep`),
-        fetcher(`${api_link}/api/inscricoes?populate=*`), // Certifique-se de que as inscrições também estão sendo populadas
-        fetcher(
-          `${api_link}/api/avaliacaos?populate[user_id][fields]=id&[populate][inscricoe][fields]=*&pagination[page]=1&pagination[pageSize]=500`
-        ),
-      ])
+    const results = await Promise.allSettled([
+      fetcher(
+        `${api_link}/api/edicoes?populate[categoria][fields]=titulo,id&[populate][inscricoes][fields]=titulo&${queri}`
+      ),
+      fetcher(`${api_link}/api/contato`),
+      fetcher(`${api_link}/api/menus?populate=deep`),
+      fetcher(`${api_link}/api/inscricoes?populate=*`),
+      fetcher(
+        `${api_link}/api/avaliacaos?populate[user_id][fields]=id&[populate][inscricoe][fields]=*&pagination[page]=1&pagination[pageSize]=500`
+      ),
+    ])
+    const [edicoes, contato, menus, inscritos, avaliacoes] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    const totalPages = Math.ceil(edicoes.meta.pagination.total / pageSize)
-    const currentPage = edicoes.meta.pagination.page
-
-    // Navbar parsing
-    const dlink =
-      navbar?.data?.flatMap(
-        (menuItem: any) =>
-          menuItem?.attributes?.items?.data?.map((linkItem: any) => ({
-            name: linkItem?.attributes?.title ?? "Unnamed",
-            link: linkItem?.attributes?.url ?? "#",
-          })) || []
-      ) || []
+    const totalPages = Math.ceil((edicoes?.meta?.pagination?.total ?? 0) / pageSize)
+    const currentPage = edicoes?.meta?.pagination?.page ?? 1
 
     return {
       props: {
-        edicoes: edicoes.data,
-        totalPages, // Add total pages for pagination
-        currentPage, // Add current page
-        social: rsocials,
-        contato,
-        navbar: dlink,
-        inscritos: inscritos.data,
-        avaliacoes,
+        edicoes: edicoes?.data ?? [],
+        totalPages,
+        currentPage,
+        social: parseNavbar(menus, "redes-social"),
+        contato: contato ?? null,
+        navbar: parseNavbar(menus, "menus"),
+        inscritos: inscritos?.data ?? [],
+        avaliacoes: avaliacoes?.data ?? [],
       },
     }
   } catch (error) {

--- a/pages/perfil/index.tsx
+++ b/pages/perfil/index.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 import Link from "next/link"
 import Head from "next/head"
 import { StrapiImage } from "../../components/custom/StrapiImage"
@@ -151,38 +152,32 @@ export async function getServerSideProps({ query }: any) {
 
   try {
     // Fetch data concurrently
-    const [edicoes, rsocials, contato, navbar, inscritos] = await Promise.all([
+    const results = await Promise.allSettled([
       fetcher(
         `${api_link}/api/edicoes?populate[categoria][fields]=titulo,id&[populate][inscricoes][fields]=titulo&${queri}`
       ),
-      fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/menus?populate=deep`),
-      fetcher(`${api_link}/api/inscricoes?populate=*`), // Certifique-se de que as inscrições também estão sendo populadas
+      fetcher(`${api_link}/api/inscricoes?populate=*`),
     ])
+    const [edicoes, contato, menus, inscritos] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    const totalPages = Math.ceil(edicoes.meta.pagination.total / pageSize)
-    const currentPage = edicoes.meta.pagination.page
-
-    // Navbar parsing
-    const dlink =
-      navbar?.data?.flatMap(
-        (menuItem: any) =>
-          menuItem?.attributes?.items?.data?.map((linkItem: any) => ({
-            name: linkItem?.attributes?.title ?? "Unnamed",
-            link: linkItem?.attributes?.url ?? "#",
-          })) || []
-      ) || []
+    const totalPages = Math.ceil((edicoes?.meta?.pagination?.total ?? 0) / pageSize)
+    const currentPage = edicoes?.meta?.pagination?.page ?? 1
 
     return {
       props: {
-        edicoes: edicoes.data,
-        totalPages, // Add total pages for pagination
-        currentPage, // Add current page
-        social: rsocials,
-        contato,
-        navbar: dlink,
-        inscritos: inscritos.data,
+        edicoes: edicoes?.data ?? [],
+        totalPages,
+        currentPage,
+        social: parseNavbar(menus, "redes-social"),
+        contato: contato ?? null,
+        navbar: parseNavbar(menus, "menus"),
+        inscritos: inscritos?.data ?? [],
       },
     }
   } catch (error) {

--- a/pages/perfil/votacaopublicaStatus.tsx
+++ b/pages/perfil/votacaopublicaStatus.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 import Head from "next/head"
 import { useFetchUser } from "../../lib/authContext"
 import Router from "next/router"
@@ -222,36 +223,32 @@ export const getServerSideProps = async () => {
     )
 
     // Fetch all data concurrently
-    const [rsocials, contato, navbar, Vpublica] = await Promise.all([
-      fetcher(`${api_link}/api/redes-social?populate=*`),
+    const results = await Promise.allSettled([
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/menus?populate=deep`),
       fetcher(`${api_link}/api/inscricoes?${query}`),
     ])
+    const [contato, menus, inscricoes] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    // Map navbar links
-    const dlink =
-      navbar?.data?.flatMap((value: any) =>
-        value?.attributes?.items?.data?.map((item: any) => ({
-          name: item?.attributes?.title ?? "",
-          link: item?.attributes?.url ?? "#",
-        })) ?? []
-      ) ?? []
 
     return {
       props: {
-        social: rsocials,
-        contato,
-        Vpublica,
-        navbar: dlink,
+        social: parseNavbar(menus, "redes-social"),
+        contato: contato ?? null,
+        Vpublica: inscricoes ?? { data: [] },
+        navbar: parseNavbar(menus, "menus"),
       },
     }
   } catch (error) {
     console.error("Error fetching data:", error)
     return {
       props: {
-        social: { data: null },
-        contato: { data: null },
+        social: [],
+        contato: null,
         Vpublica: { data: [] },
         navbar: [],
       },

--- a/pages/projetos/[id].tsx
+++ b/pages/projetos/[id].tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 // import Link from "next/link";
 import Head from "next/head"
 // import { Card } from "flowbite-react";
@@ -1184,44 +1185,26 @@ export async function getServerSideProps({ params, query }: any) {
     { encodeValuesOnly: true }
   )
 
-  // GET: links das edicoes
-  const edicoes = await fetcher(
-    `${api_link}/api/edicoes?populate[categoria][fields]=titulo,id&[populate][inscricoes][fields]=titulo&${queri}`
-  )
-  // GET: links para as redes sociais
-  const rsocials = await fetcher(`${api_link}/api/redes-social?populate=*`)
-  // GET: dados para contatos
-  const contato = await fetcher(`${api_link}/api/contato`)
-  // GET: dados do navbar
-  const navbar = await fetcher(`${api_link}/api/menus?populate=deep`)
-  // GET: dados dos projetos inscritos
-  const inscritos = await fetcher(
-    `${api_link}/api/inscricoes/${id}?populate[fileLink][populate][ficheiro][fields]=url`
-  )
-  //get links for menu
-  let dlink: any = []
-  navbar.data.map((value: any) => {
-    value.attributes.items.data.map((value: any, index: any) => {
-      // value.attributes.title;
-      // value.attributes.url;
-      // console.log(value);
-      dlink[index] = {
-        name: value.attributes.title,
-        link: value.attributes.url,
-      }
-    })
-  })
-  //   console.log("inscritos");
-  //   console.log(inscritos);
+  const results = await Promise.allSettled([
+    fetcher(`${api_link}/api/edicoes?populate[categoria][fields]=titulo,id&[populate][inscricoes][fields]=titulo&${queri}`),
+    fetcher(`${api_link}/api/contato`),
+    fetcher(`${api_link}/api/menus?populate=deep`),
+    fetcher(`${api_link}/api/inscricoes/${id}?populate[fileLink][populate][ficheiro][fields]=url`),
+  ])
 
-  // Pass data to the page via props
+  const [edicoes, contato, menus, inscritos] = results.map((r: any) => {
+    if (r.status === 'fulfilled') return r.value
+    console.error('Endpoint failed:', r.reason)
+    return null
+  })
+
   return {
     props: {
-      edicoes,
-      social: rsocials,
-      contato,
-      navbar: dlink,
-      inscricao: inscritos,
+      edicoes: edicoes ?? null,
+      social: parseNavbar(menus, "redes-social"),
+      contato: contato ?? null,
+      navbar: parseNavbar(menus, "menus"),
+      inscricao: inscritos ?? null,
     },
   }
 }

--- a/pages/projetos/index.tsx
+++ b/pages/projetos/index.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout"
 import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar"
 import Link from "next/link"
 import Head from "next/head"
 import { useFetchUser } from "../../lib/authContext"
@@ -188,38 +189,32 @@ export async function getServerSideProps({ query }: any) {
 
   try {
     // Fetch data concurrently
-    const [edicoes, rsocials, contato, navbar, inscritos] = await Promise.all([
+    const results = await Promise.allSettled([
       fetcher(
         `${api_link}/api/edicoes?populate[categoria][fields]=titulo,id&[populate][inscricoes][fields]=titulo&${queri}`
       ),
-      fetcher(`${api_link}/api/redes-social?populate=*`),
       fetcher(`${api_link}/api/contato`),
       fetcher(`${api_link}/api/menus?populate=deep`),
-      fetcher(`${api_link}/api/inscricoes?populate=*`), // Certifique-se de que as inscrições também estão sendo populadas
+      fetcher(`${api_link}/api/inscricoes?populate=*`),
     ])
+    const [edicoes, contato, menus, inscritos] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
-    const totalPages = Math.ceil(edicoes.meta.pagination.total / pageSize)
-    const currentPage = edicoes.meta.pagination.page
-
-    // Navbar parsing
-    const dlink =
-      navbar?.data?.flatMap(
-        (menuItem: any) =>
-          menuItem?.attributes?.items?.data?.map((linkItem: any) => ({
-            name: linkItem?.attributes?.title ?? "Unnamed",
-            link: linkItem?.attributes?.url ?? "#",
-          })) || []
-      ) || []
+    const totalPages = Math.ceil((edicoes?.meta?.pagination?.total ?? 0) / pageSize)
+    const currentPage = edicoes?.meta?.pagination?.page ?? 1
 
     return {
       props: {
-        edicoes: edicoes.data,
-        totalPages, // Add total pages for pagination
-        currentPage, // Add current page
-        social: rsocials,
-        contato,
-        navbar: dlink,
-        inscritos: inscritos.data,
+        edicoes: edicoes?.data ?? [],
+        totalPages,
+        currentPage,
+        social: parseNavbar(menus, "redes-social"),
+        contato: contato ?? null,
+        navbar: parseNavbar(menus, "menus"),
+        inscritos: inscritos?.data ?? [],
       },
     }
   } catch (error) {

--- a/pages/regulamentos.tsx
+++ b/pages/regulamentos.tsx
@@ -1,5 +1,6 @@
 import Layout from "../components/Layout"
 import { fetcher } from "../lib/api"
+import { parseNavbar } from "../lib/parseNavbar"
 import showdown from "showdown"
 import Head from "next/head"
 import { useFetchUser } from "../lib/authContext"
@@ -140,30 +141,23 @@ export async function getServerSideProps() {
   )
 
   try {
-    const [rsocials, contato, edicaoResponse, navbarResponse] = await Promise.all(
-      [
-        fetcher(`${api_link}/api/redes-social?populate=*`),
-        fetcher(`${api_link}/api/contato`),
-        fetcher(`${api_link}/api/edicoes?_limit=1&populate=deep&${query}`),
-        fetcher(`${api_link}/api/menus?populate=deep`),
-      ]
-    )
-
-    const edicao = edicaoResponse?.data?.[0] ?? null
-    const navbar =
-      navbarResponse?.data?.flatMap((menu: any) =>
-        menu?.attributes?.items?.data?.map((item: any) => ({
-          name: item?.attributes?.title ?? "",
-          link: item?.attributes?.url ?? "#",
-        })) ?? []
-      ) ?? []
+    const results = await Promise.allSettled([
+      fetcher(`${api_link}/api/contato`),
+      fetcher(`${api_link}/api/edicoes?_limit=1&populate=deep&${query}`),
+      fetcher(`${api_link}/api/menus?populate=deep`),
+    ])
+    const [contato, edicaoResponse, menus] = results.map((r: any) => {
+      if (r.status === 'fulfilled') return r.value
+      console.error('Endpoint failed:', r.reason)
+      return null
+    })
 
     return {
       props: {
-        social: rsocials,
-        contato,
-        edicao,
-        navbar,
+        social: parseNavbar(menus, "redes-social"),
+        contato: contato ?? null,
+        edicao: edicaoResponse?.data?.[0] ?? null,
+        navbar: parseNavbar(menus, "menus"),
       },
     }
   } catch (error) {

--- a/pages/sobreus/index.tsx
+++ b/pages/sobreus/index.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout";
-import { fetcher } from "../../lib/api";
+import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar";
 import showdown from "showdown";
 import Head from "next/head";
 import { useFetchUser } from "../../lib/authContext";
@@ -53,30 +54,23 @@ export default Sobreus;
 export async function getServerSideProps() {
   // Fetch data from external API
 
-  // GET: links para as redes sociais
-  const rsocials = await fetcher(`${api_link}/api/redes-social?populate=*`);
-  // GET: dados para contatos
-  const contato = await fetcher(`${api_link}/api/contato`);
-  // GET: dados do navbar
-  const navbar = await fetcher(`${api_link}/api/menus?populate=deep`);
-  // GET: dados do sobre Us
-  const sobreus = await fetcher(`${api_link}/api/sobre-pnp?populate=deep`);
-  //get links for menu
-  let dlink: any = [];
-  navbar.data.map((value: any) => {
-    value.attributes.items.data.map((value: any, index: any) => {
-      // value.attributes.title;
-      // value.attributes.url;
-      // console.log(value);
-      dlink[index] = {
-        name: value.attributes.title,
-        link: value.attributes.url,
-      };
-    });
-  });
+  const results = await Promise.allSettled([
+    fetcher(`${api_link}/api/contato`),
+    fetcher(`${api_link}/api/menus?populate=deep`),
+    fetcher(`${api_link}/api/sobre-pnp?populate=deep`),
+  ])
+  const [contato, menus, sobreus] = results.map((r: any) => {
+    if (r.status === 'fulfilled') return r.value
+    console.error('Endpoint failed:', r.reason)
+    return null
+  })
 
-  // Pass data to the page via props
   return {
-    props: { social: rsocials, contato, navbar: dlink, sobreus },
+    props: {
+      social: parseNavbar(menus, "redes-social"),
+      contato: contato ?? null,
+      navbar: parseNavbar(menus, "menus"),
+      sobreus: sobreus ?? null,
+    },
   };
 }

--- a/pages/sobreus/policy.tsx
+++ b/pages/sobreus/policy.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout";
-import { fetcher } from "../../lib/api";
+import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar";
 import showdown from "showdown";
 import Head from "next/head";
 import { useFetchUser } from "../../lib/authContext";
@@ -55,30 +56,23 @@ export default SobreusPolicy;
 export async function getServerSideProps() {
   // Fetch data from external API
 
-  // GET: links para as redes sociais
-  const rsocials = await fetcher(`${api_link}/api/redes-social?populate=*`);
-  // GET: dados para contatos
-  const contato = await fetcher(`${api_link}/api/contato`);
-  // GET: dados do navbar
-  const navbar = await fetcher(`${api_link}/api/menus?populate=deep`);
-  // GET: dados do sobre Us
-  const sobreus = await fetcher(`${api_link}/api/sobre-pnp?populate=deep`);
-  //get links for menu
-  let dlink: any = [];
-  navbar.data.map((value: any) => {
-    value.attributes.items.data.map((value: any, index: any) => {
-      // value.attributes.title;
-      // value.attributes.url;
-      // console.log(value);
-      dlink[index] = {
-        name: value.attributes.title,
-        link: value.attributes.url,
-      };
-    });
-  });
+  const results = await Promise.allSettled([
+    fetcher(`${api_link}/api/contato`),
+    fetcher(`${api_link}/api/menus?populate=deep`),
+    fetcher(`${api_link}/api/sobre-pnp?populate=deep`),
+  ])
+  const [contato, menus, sobreus] = results.map((r: any) => {
+    if (r.status === 'fulfilled') return r.value
+    console.error('Endpoint failed:', r.reason)
+    return null
+  })
 
-  // Pass data to the page via props
   return {
-    props: { social: rsocials, contato, navbar: dlink, sobreus },
+    props: {
+      social: parseNavbar(menus, "redes-social"),
+      contato: contato ?? null,
+      navbar: parseNavbar(menus, "menus"),
+      sobreus: sobreus ?? null,
+    },
   };
 }

--- a/pages/sobreus/terms.tsx
+++ b/pages/sobreus/terms.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout";
-import { fetcher } from "../../lib/api";
+import { fetcher } from "../../lib/api"
+import { parseNavbar } from "../../lib/parseNavbar";
 import showdown from "showdown";
 import Head from "next/head";
 import { useFetchUser } from "../../lib/authContext";
@@ -55,30 +56,23 @@ export default SobreusTerms;
 export async function getServerSideProps() {
   // Fetch data from external API
 
-  // GET: links para as redes sociais
-  const rsocials = await fetcher(`${api_link}/api/redes-social?populate=*`);
-  // GET: dados para contatos
-  const contato = await fetcher(`${api_link}/api/contato`);
-  // GET: dados do navbar
-  const navbar = await fetcher(`${api_link}/api/menus?populate=deep`);
-  // GET: dados do sobre Us
-  const sobreus = await fetcher(`${api_link}/api/sobre-pnp?populate=deep`);
-  //get links for menu
-  let dlink: any = [];
-  navbar.data.map((value: any) => {
-    value.attributes.items.data.map((value: any, index: any) => {
-      // value.attributes.title;
-      // value.attributes.url;
-      // console.log(value);
-      dlink[index] = {
-        name: value.attributes.title,
-        link: value.attributes.url,
-      };
-    });
-  });
+  const results = await Promise.allSettled([
+    fetcher(`${api_link}/api/contato`),
+    fetcher(`${api_link}/api/menus?populate=deep`),
+    fetcher(`${api_link}/api/sobre-pnp?populate=deep`),
+  ])
+  const [contato, menus, sobreus] = results.map((r: any) => {
+    if (r.status === 'fulfilled') return r.value
+    console.error('Endpoint failed:', r.reason)
+    return null
+  })
 
-  // Pass data to the page via props
   return {
-    props: { social: rsocials, contato, navbar: dlink, sobreus },
+    props: {
+      social: parseNavbar(menus, "redes-social"),
+      contato: contato ?? null,
+      navbar: parseNavbar(menus, "menus"),
+      sobreus: sobreus ?? null,
+    },
   };
 }


### PR DESCRIPTION
Migrate remaining pages from sequential fetchers / Promise.all to Promise.allSettled, add results.map destructuring where missing, replace old flatMap navbar patterns with parseNavbar(), and remove dead redes-social endpoint calls. All pages now survive individual API failures without crashing. TypeScript clean, 51/51 tests pass.